### PR TITLE
[Security] Attachment URLs stay inside ~/.taskuary/attachments, and SVG never scripts as the app

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,5 +41,8 @@ notes below are what follows from it.
 
 - Give GitHub PATs the narrowest repository access and permission set that works.
 - Keep `~/.taskuary/` out of backups that sync somewhere you don't control.
+- Attachment URLs only serve files under `~/.taskuary/attachments/` — a `Path` that
+  escaped that folder is a 404. SVG/HTML always download; they are not rendered as a
+  document on the app origin.
 - Read `~/.taskuary/taskuary.log` and the in-app audit log (Settings → Audit integrity —
   it's a hash chain) if you want to know what ran and when.

--- a/taskuary/server.py
+++ b/taskuary/server.py
@@ -351,6 +351,29 @@ def _att_row(a: dict) -> dict:
             'is_image': str(a['ContentType'] or '').startswith('image/'),
             'url': f"/api/attachments/{a['AttachmentId']}" if a['Path'] else None}
 
+# SVG/HTML as a navigable document on this origin runs script as Taskuary. PNG/JPEG
+# stay `inline` so the panel <img> can draw them; SVG still displays in <img> with
+# Content-Disposition: attachment (the tab-open case is what this blocks).
+_NOSCRIPT = ('image/svg+xml', 'image/svg', 'text/html', 'application/xhtml+xml',
+             'text/xml', 'application/xml', 'text/javascript', 'application/javascript')
+
+def _attachment_path(raw: str):
+    """The file on disk, if it is really one of ours. A Path column pointing outside
+    ~/.taskuary/attachments would turn GET /api/attachments/:id into a local file read."""
+    if not raw: return None
+    p, root = Path(raw).resolve(), (config.home() / 'attachments').resolve()
+    try:
+        if not p.is_relative_to(root) or not p.is_file(): return None
+    except (OSError, ValueError):
+        return None
+    return p
+
+def _att_filename(name: str) -> str:
+    """Content-Disposition cannot carry CR/LF or a path - take the first line, then
+    the basename. Mail names are mostly cleaned on save; this is the last gate."""
+    n = Path((str(name or 'attachment').splitlines() or ['attachment'])[0]).name[:120]
+    return n or 'attachment'
+
 @app.get('/api/messages/{mid}/attachments')
 def message_attachments(mid: int):
     if not store.get_message(mid): raise HTTPException(404, 'message not found')
@@ -359,14 +382,19 @@ def message_attachments(mid: int):
 @app.get('/api/attachments/{aid}')
 def attachment(aid: int, download: bool = False):
     """The bytes. Images are served inline so the panel can just draw them; everything else
-    downloads under its own name."""
+    downloads under its own name. Path is confined to the attachments dir; SVG/HTML never
+    render as a document on this origin."""
     a = store.get_attachment(aid)
     if not a: raise HTTPException(404, 'attachment not found')
-    if not a['Path'] or not Path(a['Path']).exists():
+    path = _attachment_path(a.get('Path'))
+    if not path:
         raise HTTPException(404, 'this one was never saved - open the original message for it')
-    disp = 'attachment' if (download or not str(a['ContentType'] or '').startswith('image/')) else 'inline'
-    return FileResponse(a['Path'], media_type=a['ContentType'] or 'application/octet-stream',
-                        filename=a['Name'], content_disposition_type=disp)
+    ct = (a.get('ContentType') or 'application/octet-stream').split(';')[0].strip() or 'application/octet-stream'
+    inline = (not download) and ct.lower().startswith('image/') and ct.lower() not in _NOSCRIPT
+    resp = FileResponse(path, media_type=ct, filename=_att_filename(a.get('Name')),
+                        content_disposition_type='inline' if inline else 'attachment')
+    resp.headers['X-Content-Type-Options'] = 'nosniff'
+    return resp
 
 @app.post('/api/messages/{mid}/attachments/fetch')
 def fetch_attachments(mid: int):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -97,6 +97,33 @@ class ApiTests(unittest.TestCase):
         self.assertEqual(c.post(f'/api/messages/{mid}/attachments/fetch', json={}).status_code, 422)  # no Outlook connection
         self.assertEqual(c.get('/api/messages/999999/attachments').status_code, 404)
 
+    def test_attachment_url_stays_in_the_attachments_dir_and_does_not_script(self):
+        """A Path pointing at config.toml used to be served as the attachment. SVG marked
+        image/svg+xml used to render as a document on this origin when opened in a tab,
+        and a CR/LF in the filename used to split Content-Disposition."""
+        from taskuary import artifacts
+        mid = server.store.add_message({'ExternalId': 'graph:ATTESC', 'Channel': 'email',
+                                        'Subject': 'escaped', 'Status': 'filed'})
+        outside = config.home() / 'not-an-attachment.txt'
+        outside.write_text('secret', encoding='utf-8')
+        aid_out = server.store.add_attachment({'MessageId': mid, 'ExternalId': 'esc:out',
+                                               'Name': 'secrets.txt', 'ContentType': 'text/plain',
+                                               'Path': str(outside)})
+        self.assertEqual(c.get(f'/api/attachments/{aid_out}').status_code, 404)
+        svg = artifacts.attachment_dir(mid) / '0-chart.svg'
+        svg.write_text('<svg xmlns="http://www.w3.org/2000/svg"></svg>', encoding='utf-8')
+        aid_svg = server.store.add_attachment({'MessageId': mid, 'ExternalId': 'esc:svg',
+                                              'Name': 'chart.svg\r\nX-Injected: yes',
+                                              'ContentType': 'image/svg+xml', 'Path': str(svg)})
+        r = c.get(f'/api/attachments/{aid_svg}')
+        self.assertEqual(r.status_code, 200)
+        disp = r.headers.get('content-disposition', '')
+        self.assertIn('attachment', disp)
+        self.assertNotIn('\r', disp)
+        self.assertNotIn('X-Injected', disp)
+        self.assertEqual(r.headers.get('x-content-type-options'), 'nosniff')
+        self.assertEqual(r.headers.get('content-type', '').split(';')[0].strip(), 'image/svg+xml')
+
     def test_settings_roundtrip(self):
         self.assertEqual(c.patch('/api/settings', json={'name': 'feed_days', 'value': '7'}).json(), {'ok': True})
         vals = {s['Name']: s['Value'] for s in c.get('/api/settings').json()['data']}

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -139,7 +139,8 @@ class ReportOutputApiTests(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
         self.assertIn('Spend by vendor', r.text)                        # the AI's title, not the guess
         self.assertIn('amount by vendor', r.text)
-        self.assertIn('inline', r.headers.get('content-disposition', ''))
+        # SVG as a document on this origin is XSS; the panel still draws it via <img>
+        self.assertIn('attachment', r.headers.get('content-disposition', ''))
         # the spreadsheet is a download, and a real zip
         self.assertIn('attachment', self.c.get(sheet['url']).headers.get('content-disposition', ''))
         self.assertEqual(self.c.get(sheet['url']).content[:2], b'PK')


### PR DESCRIPTION
## What & why

`GET /api/attachments/:id` used to serve whatever path was in the row, and SVG/HTML with `Content-Disposition: inline` rendered as a document on the Taskuary origin (open-in-new-tab XSS). Paths are now confined to `~/.taskuary/attachments/`, scriptable types always download, filenames cannot split the header, and responses send `X-Content-Type-Options: nosniff`. The panel still draws images via `<img>`.

## Checklist

- [x] `python -m pytest -q` passes (offline, no credentials)
- [x] New behavior has a test
- [x] UI untouched → `taskuary/web/` rebuilt & committed, `render_check.mjs` clean, no screenshot required
- [x] README updated if users can see the change — no README change (panel behaviour unchanged); `SECURITY.md` hygiene note added
