### PR TITLE
[Security] Agents cannot run a connector that is off, even when it shipped with the tool role

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,7 +27,9 @@ notes below are what follows from it.
 - **The API executes things by design.** Reports run SQL and PowerShell, `/api/tools/run`
   runs a connector's query or script, agent dispatch runs your configured CLI, and the
   terminal opens a real shell — all with your credentials, on your machine. Anyone who
-  can reach the API can do those things.
+  can reach the API can do those things. `/api/tools/run` still refuses a catalog
+  connection that is off or not marked *tool* (cards are seeded on first launch, so
+  "never connected" is not the same as "no row").
 - **Credentials are stored locally in plaintext** in `~/.taskuary/taskuary.db` and
   `config.toml`. They are write-only through the UI (never returned to the browser), but
   the files themselves are only as protected as your user account and disk encryption.

--- a/taskuary/server.py
+++ b/taskuary/server.py
@@ -748,12 +748,17 @@ def tool_run(body: dict):
     the owner marked as a tool, and get the raw output back (no AI pass, no timeline row).
     Same executors the Reports tab uses, same saved credentials - so an agent working a
     task can look something up in SQL Server, run a script on a box, or call an MCP tool.
-    A connection without the 'tool' role refuses."""
+    Catalog cards exist from first launch (winrm/mssql already have the tool role in
+    DEFAULT_ROLES) even when the owner never connected them - off means off. A connection
+    without the 'tool' role also refuses."""
     t = (body or {}).get('type')
     if t not in REGISTRY: raise HTTPException(422, f'unknown tool type: {t}')
     conn = store.get_connector_by_type(t)
-    if conn and 'tool' not in store_mod.roles_of(conn):
-        raise HTTPException(403, f'the {t} connection is not marked as an agent tool (Connectors → {t} → Role)')
+    if conn:
+        if not conn.get('Active'):
+            raise HTTPException(403, f'the {t} connection is off - turn it on under Connectors')
+        if 'tool' not in store_mod.roles_of(conn):
+            raise HTTPException(403, f'the {t} connection is not marked as an agent tool (Connectors → {t} → Role)')
     try:
         head, out = REGISTRY[t](resolve_cfg(store, {**body, 'type': t}))
     except Exception as e:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -128,17 +128,20 @@ class ApiTests(unittest.TestCase):
             REGISTRY.pop('_t')
 
     def test_tool_run_needs_the_tool_role(self):
-        """An agent using a connected system: allowed for tool-role connections, refused
-        otherwise, and errors come back as data instead of a 500."""
+        """An agent using a connected system: allowed for tool-role connections that are ON,
+        refused otherwise, and errors come back as data instead of a 500. Catalog cards are
+        seeded with the tool role from first launch - Active is what 'I set this up' means."""
         REGISTRY['_tool'] = lambda cfg: (f"ran {cfg.get('q')}", 'rows here')
         try:
             r = c.post('/api/tools/run', json={'type': '_tool', 'q': 'select 1'}).json()
             self.assertEqual((r['ok'], r['headline'], r['output']), (True, 'ran select 1', 'rows here'))
             self.assertEqual(c.post('/api/tools/run', json={'type': 'nope'}).status_code, 422)
             cid = next(x['ConnectorId'] for x in c.get('/api/connectors').json()['data'] if x['Type'] == 'winrm')
-            c.post('/api/connectors', json={'ConnectorId': cid, 'Roles': 'report'})
+            # seeded: tool role, Active=0. Used to run anyway.
             self.assertEqual(c.post('/api/tools/run', json={'type': 'winrm', 'script': 'hostname'}).status_code, 403)
-            c.post('/api/connectors', json={'ConnectorId': cid, 'Roles': 'report,tool'})
+            c.post('/api/connectors', json={'ConnectorId': cid, 'Roles': 'report', 'Active': True})
+            self.assertEqual(c.post('/api/tools/run', json={'type': 'winrm', 'script': 'hostname'}).status_code, 403)
+            c.post('/api/connectors', json={'ConnectorId': cid, 'Roles': 'report,tool', 'Active': True})
             REGISTRY['winrm'], real = lambda cfg: (_ for _ in ()).throw(RuntimeError('box unreachable')), REGISTRY['winrm']
             try:
                 out = c.post('/api/tools/run', json={'type': 'winrm', 'script': 'hostname'}).json()


### PR DESCRIPTION
## What & why

`/api/tools/run` checked the *tool* role but not `Active`. Catalog cards (WinRM, SQL Server, …) are inserted on first launch with the tool role already set and `Active=0`. A prompt-injected agent (or anything that can POST localhost) could still run PowerShell/SQL through a card the owner never turned on. SOUL.md already only advertised tools for *active* connections; the endpoint now matches that. Off → 403; on but not *tool* → 403 as before.

## Checklist

- [x] `python -m pytest -q` passes (offline, no credentials)
- [x] New behavior has a test
- [x] UI untouched → `taskuary/web/` rebuilt & committed, `render_check.mjs` clean, screenshot below
- [x] README updated if users can see the change — no README change (Connectors already have on/off); `SECURITY.md` notes the gate
